### PR TITLE
Refactor extract_last_item to resolve #14

### DIFF
--- a/lib/company_info.ex
+++ b/lib/company_info.ex
@@ -1,4 +1,7 @@
 defmodule SecCompanyFilingsRssFeedParser.CompanyInfo do
+  @moduledoc false
+
+  use ParseUtility
 
   def parse(xml) do
     %{
@@ -17,85 +20,69 @@ defmodule SecCompanyFilingsRssFeedParser.CompanyInfo do
     }
   end
 
-  def extract_last_item(tuple) do
-    {_, _, item} = tuple
-    item |> hd
-  end
-
   defp parse_assigned_sic(xml) do
     xml
     |> Floki.find("assigned-sic")
-    |> hd
     |> extract_last_item
   end
 
   defp parse_assigned_sic_desc(xml) do
     xml
     |> Floki.find("assigned-sic-desc")
-    |> hd
     |> extract_last_item
   end
 
   defp parse_assigned_sic_href(xml) do
     xml
     |> Floki.find("assigned-sic-href")
-    |> hd
     |> extract_last_item
   end
 
   defp parse_assitant_director(xml) do
     xml
     |> Floki.find("assitant-director")
-    |> hd
     |> extract_last_item
   end
 
   defp parse_cik(xml) do
     xml
     |> Floki.find("cik")
-    |> hd
     |> extract_last_item
   end
 
   defp parse_cik_href(xml) do
     xml
     |> Floki.find("cik-href")
-    |> hd
     |> extract_last_item
   end
 
   defp parse_conformed_name(xml) do
     xml
     |> Floki.find("conformed-name")
-    |> hd
     |> extract_last_item
   end
 
   defp parse_fiscal_year_end(xml) do
     xml
     |> Floki.find("fiscal-year-end")
-    |> hd
     |> extract_last_item
   end
 
   defp parse_state_location(xml) do
     xml
     |> Floki.find("state-location")
-    |> hd
     |> extract_last_item
   end
 
   defp parse_state_location_href(xml) do
     xml
     |> Floki.find("state-location-href")
-    |> hd
     |> extract_last_item
   end
 
   defp parse_state_of_incorporation(xml) do
     xml
     |> Floki.find("state-of-incorporation")
-    |> hd
     |> extract_last_item
   end
 
@@ -131,4 +118,3 @@ defmodule SecCompanyFilingsRssFeedParser.CompanyInfo do
     ]
   end
 end
-

--- a/lib/entry.ex
+++ b/lib/entry.ex
@@ -10,6 +10,8 @@ defmodule SecCompanyFilingsRssFeedParser.Entry do
   parse/1 takes an xml entry and parses it and returns a map of entry
   """
 
+  use ParseUtility
+
   def parse(xml) do
     %{
       updated: parse_updated(xml),
@@ -30,42 +32,22 @@ defmodule SecCompanyFilingsRssFeedParser.Entry do
     }
   end
 
-  def extract_last_item(tuple) do
-    {_, _, item} = tuple
-    item |> hd
-  end
-
   defp parse_updated(xml) do
-    updated = xml
+    xml
     |> Floki.find("updated")
-
-    if updated == [] do
-      nil
-    else
-      updated |> hd |> extract_last_item
-    end
+    |> extract_last_item()
   end
 
   defp parse_form_name(xml) do
-    form_name = xml
+    xml
     |> Floki.find("form-name")
-
-    if form_name == [] do
-      nil
-    else
-      form_name |> hd |> extract_last_item
-    end
+    |> extract_last_item()
   end
 
   defp parse_title(xml) do
-    title = xml
+    xml
     |> Floki.find("title")
-
-    if title == [] do
-      nil
-    else
-      title |> hd |> extract_last_item
-    end
+    |> extract_last_item()
   end
 
   defp parse_summary(xml) do
@@ -80,14 +62,9 @@ defmodule SecCompanyFilingsRssFeedParser.Entry do
   end
 
   defp parse_rss_feed_id(xml) do
-    rss_feed_id = xml
+    xml
     |> Floki.find("id")
-
-    if rss_feed_id == [] do
-      nil
-    else
-      rss_feed_id |> hd |> extract_last_item
-    end
+    |> extract_last_item()
   end
 
   defp parse_size(xml) do
@@ -99,47 +76,27 @@ defmodule SecCompanyFilingsRssFeedParser.Entry do
   end
 
   defp parse_film_number(xml) do
-    film_number = xml
+    xml
     |> Floki.find("film-number")
-
-    if film_number == [] do
-      nil
-    else
-      film_number |> hd |> extract_last_item
-    end
+    |> extract_last_item()
   end
 
   defp parse_filing_type(xml) do
-    filing_type = xml
+    xml
     |> Floki.find("filing-type")
-
-    if filing_type == [] do
-      nil
-    else
-      filing_type |> hd |> extract_last_item
-    end
+    |> extract_last_item()
   end
 
   defp parse_filing_date(xml) do
-    filing_date = xml
+    xml
     |> Floki.find("filing-date")
-
-    if filing_date == [] do
-      nil
-    else
-      filing_date |> hd |> extract_last_item
-    end
+    |> extract_last_item()
   end
 
   defp parse_file_name_href(xml) do
-    file_name = xml
+    xml
     |> Floki.find("file-number-href")
-
-    if file_name == [] do
-      nil
-    else
-      file_name |> hd |> extract_last_item
-    end
+    |> extract_last_item()
   end
 
   defp parse_category_term(xml) do
@@ -155,35 +112,20 @@ defmodule SecCompanyFilingsRssFeedParser.Entry do
   end
 
   defp parse_accession_nunber(xml) do
-    accession_nunber = xml
+    xml
     |> Floki.find("accession-nunber")
-
-    if accession_nunber == [] do
-      nil
-    else
-      accession_nunber |> hd |> extract_last_item
-    end
+    |> extract_last_item()
   end
 
   defp parse_act(xml) do
-    act = xml
+    xml
     |> Floki.find("act")
-
-    if act == [] do
-      nil
-    else
-      act |> hd |> extract_last_item
-    end
+    |> extract_last_item()
   end
 
   defp parse_file_number(xml) do
-    file_number = xml
+    xml
     |> Floki.find("file-number")
-
-    if file_number == [] do
-      nil
-    else
-      file_number |> hd |> extract_last_item
-    end
+    |> extract_last_item()
   end
 end

--- a/lib/feed.ex
+++ b/lib/feed.ex
@@ -1,4 +1,9 @@
 defmodule SecCompanyFilingsRssFeedParser.Feed do
+  @moduledoc false
+
+  use ParseUtility
+
+  alias SecCompanyFilingsRssFeedParser.{CompanyInfo, Entry}
 
   def parse(xml) do
     %{
@@ -11,21 +16,17 @@ defmodule SecCompanyFilingsRssFeedParser.Feed do
     }
   end
 
-  def extract_last_item(tuple) do
-    {_, _, item} = tuple
-    item |> hd
-  end
-
   defp parse_entries(xml) do
-    Floki.find(xml, "entry")
-    |> Enum.map(fn entry -> SecCompanyFilingsRssFeedParser.Entry.parse(Floki.raw_html(entry)) end)
+    xml
+    |> Floki.find("entry")
+    |> Enum.map(fn entry -> Entry.parse(Floki.raw_html(entry)) end)
   end
 
   defp parse_company_info(xml) do
     xml
     |> Floki.find("company-info")
     |> Floki.raw_html
-    |> SecCompanyFilingsRssFeedParser.CompanyInfo.parse
+    |> CompanyInfo.parse
   end
 
   defp parse_updated(feed) do
@@ -39,20 +40,22 @@ defmodule SecCompanyFilingsRssFeedParser.Feed do
 
   defp parse_title(feed) do
     {_, _, [title]} =
-    feed |>
-    Floki.find("title")
+    feed
+    |> Floki.find("title")
     |> List.last
 
     title
   end
 
   defp parse_author_name(feed) do
-    feed |> Floki.find("author name") |> hd
-    |> extract_last_item
+    feed
+    |> Floki.find("author name")
+    |> extract_last_item()
   end
 
   defp parse_author_email(feed) do
-    feed |> Floki.find("author email") |> hd
-    |> extract_last_item
+    feed
+    |> Floki.find("author email")
+    |> extract_last_item()
   end
 end

--- a/lib/parse_utility.ex
+++ b/lib/parse_utility.ex
@@ -1,0 +1,15 @@
+defmodule ParseUtility do
+  @moduledoc "a module to hold common helper functions"
+
+  defmacro __using__(_opts) do
+    quote do
+
+      def extract_last_item([]), do: nil
+
+      def extract_last_item([tuple | _]) do
+        {_, _, [last_item | _]} = tuple
+        last_item
+      end
+    end
+  end
+end

--- a/lib/sec_company_filings_rss_feed_parser.ex
+++ b/lib/sec_company_filings_rss_feed_parser.ex
@@ -4,8 +4,10 @@ defmodule SecCompanyFilingsRssFeedParser do
   handles errors if there are issues generating it
   """
 
+  alias SecCompanyFilingsRssFeedParser.Feed
+
   def parse(xml) do
-    {:ok, SecCompanyFilingsRssFeedParser.Feed.parse(xml)}
+    {:ok, Feed.parse(xml)}
   catch
     :exit, _ -> {:error, "expected element start tag"}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,11 +5,11 @@ defmodule SecCompanyFilingsRssFeedParser.Mixfile do
     [app: :sec_company_filings_rss_feed_parser,
      version: "0.0.3",
      elixir: "~> 1.2",
-     description: description,
+     description: description(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     package: package,
-     deps: deps]
+     package: package(),
+     deps: deps()]
   end
 
   def application do

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"floki": {:hex, :floki, "0.8.0"},
+%{
+  "floki": {:hex, :floki, "0.8.1", "06aa75bf2d1e01cda7d2ad54f68614be653a11e76b474d8fcb1d838f8c1e0ad1", [:mix], [{:mochiweb_html, "~> 2.15", [hex: :mochiweb_html, repo: "hexpm", optional: false]}], "hexpm"},
   "mochiweb": {:hex, :mochiweb, "2.12.2"},
-  "mochiweb_html": {:hex, :mochiweb_html, "2.13.0"}}
+  "mochiweb_html": {:hex, :mochiweb_html, "2.15.0", "d7402e967d7f9f2912f8befa813c37be62d5eeeddbbcb6fe986c44e01460d497", [:rebar3], [], "hexpm"},
+}

--- a/test/company_info_test.exs
+++ b/test/company_info_test.exs
@@ -43,62 +43,62 @@ defmodule SecCompanyFilingsRssFeedParserCompanyInfoTest do
   end
 
   test "parses assigned-sic" do
-    company_info = company_info_xml |> parse
+    company_info = company_info_xml() |> parse
     assert company_info.assigned_sic == "7370"
   end
 
   test "parses assigned-sic-desc" do
-    company_info = company_info_xml |> parse
+    company_info = company_info_xml() |> parse
     assert company_info.assigned_sic_desc == "SERVICES-COMPUTER PROGRAMMING, DATA PROCESSING, ETC."
   end
 
   test "parses assigned-sic-href" do
-    company_info = company_info_xml |> parse
+    company_info = company_info_xml() |> parse
     assert company_info.assigned_sic_href == "http://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&SIC=7370&owner=exclude&count=40"
   end
 
   test "parses assitant director" do
-    company_info = company_info_xml |> parse
+    company_info = company_info_xml() |> parse
     assert company_info.assitant_director == "3"
   end
 
   test "parses cik" do
-    company_info = company_info_xml |> parse
+    company_info = company_info_xml() |> parse
     assert company_info.cik == "0001418091"
   end
 
   test "parses cik-href" do
-    company_info = company_info_xml |> parse
+    company_info = company_info_xml() |> parse
     assert company_info.cik_href == "http://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK=0001418091&owner=exclude&count=40"
   end
 
   test "parses conformed-name" do
-    company_info = company_info_xml |> parse
+    company_info = company_info_xml() |> parse
     assert company_info.conformed_name == "TWITTER, INC."
   end
 
   test "parses fiscal-year-end" do
-    company_info = company_info_xml |> parse
+    company_info = company_info_xml() |> parse
     assert company_info.fiscal_year_end == "1231"
   end
 
   test "parses state-location" do
-    company_info = company_info_xml |> parse
+    company_info = company_info_xml() |> parse
     assert company_info.state_location == "CA"
   end
 
   test "parses state-location-href" do
-    company_info = company_info_xml |> parse
+    company_info = company_info_xml() |> parse
     assert company_info.state_location_href == "http://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&State=CA&owner=exclude&count=40"
   end
 
   test "parses state-of-incorporation" do
-    company_info = company_info_xml |> parse
+    company_info = company_info_xml() |> parse
     assert company_info.state_of_incorporation == "DE"
   end
 
   test "parses addresses" do
-    company_info = company_info_xml |> parse
+    company_info = company_info_xml() |> parse
     assert company_info.addresses ==
       [
         %{

--- a/test/entry_test.exs
+++ b/test/entry_test.exs
@@ -29,77 +29,77 @@ defmodule SecCompanyFilingsRssFeedParserEntryTest do
   end
 
   test "parses updated date" do
-    entry = entry_xml |> parse
+    entry = entry_xml() |> parse
     assert entry.updated == "2016-03-01T06:02:42-05:00"
   end
 
   test "parses title" do
-    entry = entry_xml |> parse
+    entry = entry_xml() |> parse
     assert entry.title == "S-8  - Securities to be offered to employees in employee benefit plans"
   end
 
   test "parses summary" do
-    entry = entry_xml |> parse
+    entry = entry_xml() |> parse
     assert entry.summary == " <b>Filed:</b> 2016-03-01 <b>AccNo:</b> 0001564590-16-013773 <b>Size:</b> 146 KB"
   end
 
   test "parses link" do
-    entry = entry_xml |> parse
+    entry = entry_xml() |> parse
     assert entry.link == "http://www.sec.gov/Archives/edgar/data/1418091/000156459016013773/0001564590-16-013773-index.htm"
   end
 
   test "parses rss_feed_id" do
-    entry = entry_xml |> parse
+    entry = entry_xml() |> parse
     assert entry.rss_feed_id == "urn:tag:sec.gov,2008:accession-number=0001564590-16-013773"
   end
 
   test "parses size" do
-    entry = entry_xml |> parse
+    entry = entry_xml() |> parse
     assert entry.size == "146 KB"
   end
 
   test "parses form-name" do
-    entry = entry_xml |> parse
+    entry = entry_xml() |> parse
     assert entry.form_name == "Securities to be offered to employees in employee benefit plans"
   end
 
   test "parses film-number" do
-    entry = entry_xml |> parse
+    entry = entry_xml() |> parse
     assert entry.film_number == "161470856"
   end
 
   test "parsess filing-type" do
-    entry = entry_xml |> parse
+    entry = entry_xml() |> parse
     assert entry.filing_type == "S-8"
   end
 
   test "parses filing-date" do
-    entry = entry_xml |> parse
+    entry = entry_xml() |> parse
     assert entry.filing_date == "2016-03-01"
   end
 
   test "parses file-number-href" do
-    entry = entry_xml |> parse
+    entry = entry_xml() |> parse
     assert entry.file_number_href == "http://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&filenum=333-209840&owner=exclude&count=40"
   end
 
   test "parses category term" do
-    entry = entry_xml |> parse
+    entry = entry_xml() |> parse
     assert entry.category_term == "S-8"
   end
 
   test "parses accession nunber" do
-    entry = entry_xml |> parse
+    entry = entry_xml() |> parse
     assert entry.accession_nunber == "0001564590-16-013773"
   end
 
   test "parses act" do
-    entry = entry_xml |> parse
+    entry = entry_xml() |> parse
     assert entry.act == "33"
   end
 
   test "parses file-number" do
-    entry = entry_xml |> parse
+    entry = entry_xml() |> parse
     assert entry.file_number == "333-209840"
   end
 end

--- a/test/feed_test.exs
+++ b/test/feed_test.exs
@@ -1,6 +1,8 @@
 defmodule SecCompanyFilingsRssFeedParserFeedTest do
   use ExUnit.Case
 
+  alias SecCompanyFilingsRssFeedParser.Feed
+
   def feed_xml do
     """
     <?xml version="1.0" encoding="ISO-8859-1" ?>
@@ -95,7 +97,7 @@ defmodule SecCompanyFilingsRssFeedParserFeedTest do
   end
 
   test "parse/1" do
-    feed = feed_xml |> SecCompanyFilingsRssFeedParser.Feed.parse
+    feed = feed_xml() |> Feed.parse
 
     assert feed == %{
       updated: "2016-03-03T18:20:09-05:00",
@@ -126,7 +128,7 @@ defmodule SecCompanyFilingsRssFeedParserFeedTest do
             act: "34",
             category_term: "10-K",
             file_number: "001-36164",
-            file_number_href: "http://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&filenum=001-36164&owner=exclude&count=40", 
+            file_number_href: "http://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&filenum=001-36164&owner=exclude&count=40",
             filing_date: "2016-02-29",
             filing_type: "10-K",
             film_number: "161464790",
@@ -173,7 +175,7 @@ defmodule SecCompanyFilingsRssFeedParserFeedTest do
 
   test "parse/1 on entire xml file works" do
     feed_xml = File.read!("test/fixtures/company_filings_rss_feed.xml")
-    feed = feed_xml |> SecCompanyFilingsRssFeedParser.Feed.parse
+    feed = feed_xml |> Feed.parse
     assert feed.updated == "2016-03-03T18:20:09-05:00"
     assert feed.title == "TWITTER, INC.  (0001418091)"
   end

--- a/test/sec_company_filings_rss_feed_parser_test.exs
+++ b/test/sec_company_filings_rss_feed_parser_test.exs
@@ -15,6 +15,6 @@ defmodule SecCompanyFilingsRssFeedParserTest do
 
   test "has an entry" do
     {:ok, xml} = File.read("test/fixtures/company_filings_rss_feed.xml")
-    {:ok, feed} = xml |> parse
+    {:ok, _feed} = xml |> parse
   end
 end


### PR DESCRIPTION
This commit extracts extract_last_item function into a ParseUtility module
Functions that use extract_last_item are refactored to use the extracted
function.

This was also refactored to remove warnings by adding () to 0-arity functions, 
removing extra lines, removing white space, etc.